### PR TITLE
elf(3): Small grammar fix

### DIFF
--- a/libelf/elf.3
+++ b/libelf/elf.3
@@ -576,7 +576,7 @@ set by function
 .Ss Error Handling
 In case an error is encountered, these library functions set an
 internal error number and signal the presence of the error by
-returning an special return value.
+returning a special return value.
 The application can check the
 current error number by calling
 .Xr elf_errno 3 .


### PR DESCRIPTION
elf(3): Small grammar fix

Obtained from: OpenBSD